### PR TITLE
fix(cn): portrait URL — backup/ is excluded from site build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,7 +112,7 @@ disqus:
 # --------------------------------------------------
 include: [".htaccess"]           # Files to force-include in the build
 exclude:                         # Folders/files ignored during build
-  - "backup"                     # Old drafts & duplicate permalinks; do not publish
+  - "backup"                     # Old drafts & duplicate permalinks; do not publish (no static assets here — use /images/ or site root)
   - "lib"
   - "config.rb"
   - "Capfile"

--- a/cn.md
+++ b/cn.md
@@ -6,7 +6,7 @@ title: 蔡汉霖的个人主页
 
 ## 关于我
 
-<img src="{{ "/backup/caihalin(2025).PNG" | relative_url }}" class="floatpic" alt="蔡汉霖">
+<img src="{{ "/caihanlin.jpg" | relative_url }}" class="floatpic" alt="蔡汉霖">
 
 <br>首先感谢您的阅读。我是蔡汉霖，2002年生，福建泉州人。国家公派学者。
 


### PR DESCRIPTION
Use /caihanlin.jpg (same as English index) so the image is published. Note in _config exclude comment: do not host live assets under backup/.