### PR TITLE
Remove unsupported Star History embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,6 @@ This site is a **[Jekyll](https://jekyllrb.com/)** project built by **[GitHub Pa
 
 For a deeper walkthrough (including local preview with Ruby/Jekyll), see the [website building tutorial](https://caihanlin.com/blogs/web/) on the blog.
 
-## Star History
-
-**If you like it, please STAR it! 🥰**
-[![Star History Chart](https://api.star-history.com/svg?repos=GuangLun2000/GuangLun2000.github.io&type=Date)](https://www.star-history.com/#GuangLun2000/GuangLun2000.github.io&Date)
-
 ## Statement
 
 © Hanlin Cai. Published with [GitHub Pages](https://pages.github.com/), powered by [Jekyll](https://jekyllrb.com/), based on the [Minimal Mistakes](https://mademistakes.com/) theme and [Jason Ansel's site](https://github.com/jansel/jansel.github.io). Source code for this website can be found [here](https://github.com/GuangLun2000/GuangLun2000.github.io).

--- a/blogs.md
+++ b/blogs.md
@@ -55,13 +55,6 @@ title: Blogs
 
 <br>
 
-## Web Star History 点赞记录
-
-- 如果你喜欢这个站点，请为我的[Github仓库](https://github.com/GuangLun2000/GuangLun2000.github.io)留下一个Star吧！
-- [Leave a Github Star if you like it 🥰 Thank you so much!](https://github.com/GuangLun2000/GuangLun2000.github.io) 
-
-<br>[![Star History Chart](https://api.star-history.com/svg?repos=GuangLun2000/GuangLun2000.github.io&type=Date)](https://star-history.com/#GuangLun2000/GuangLun2000.github.io&Date)
-
 Finally, my WeChat account is - lancecai2002
 
 <br>

--- a/blogs/summer-res.md
+++ b/blogs/summer-res.md
@@ -16,14 +16,6 @@ title: summer-res
 
 <br>
 
-----
-
-## Star History
-
-<br>[![Star History Chart](https://api.star-history.com/svg?repos=GuangLun2000/summer-research-app&type=Date)](https://star-history.com/#GuangLun2000/summer-research-app&Date)
-
-<br>
-
 ---
 
 ## Useful Links

--- a/blogs/team2023.md
+++ b/blogs/team2023.md
@@ -37,8 +37,6 @@ title: 团队经历大于获奖本身!
 - [2024年福大数模培训分享会直播-蔡汉霖团队分享🔗](https://meeting.tencent.com/user-center/shared-record-info?id=6a5b1dea-3b04-45eb-889b-8c2d347215af&from=3)
 - [@B站，可能是全网最好的美赛绘图指南｜蔡汉霖Lance🔗]( https://www.bilibili.com/video/BV1wg4y1e7Gg/?share_source=copy_web&vd_source=c8936a3bacfd65375f9e88b3bb9a12ba)
 
-<br>[![Star History Chart](https://api.star-history.com/svg?repos=GuangLun2000/COMAP-MCM-2023&type=Date)](https://star-history.com/#GuangLun2000/COMAP-MCM-2023&Date)
-
 <br>
 
 ## Useful Links


### PR DESCRIPTION
## What changed

- Removed all Star History headings, charts, API embeds, and Star History links from the README and blog pages.
- Removed the now-unused Star History presentation blocks while preserving unrelated GitHub Star support messages.

## Why

The Star History service is no longer supported, so the site should not render broken or unavailable embeds.

## Validation

- Confirmed there are no remaining `Star History`, `star-history`, or `star_history` references in the repository.
- `git diff --check` passed.
